### PR TITLE
Feat#44 메모 api 구현

### DIFF
--- a/src/main/java/com/seasonthon/everflow/app/global/code/status/ErrorStatus.java
+++ b/src/main/java/com/seasonthon/everflow/app/global/code/status/ErrorStatus.java
@@ -61,6 +61,11 @@ public enum ErrorStatus implements BaseErrorCode {
     GEMINI_CALL_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "GEMINI5031", "Gemini 호출에 실패했습니다."),
     GEMINI_EMPTY_QUESTION(HttpStatus.UNPROCESSABLE_ENTITY, "GEMINI4221", "생성된 질문이 비어 있습니다."),
 
+    // == Memo 관련 에러 ==
+    MEMO_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMO4041", "공유 메모를 찾을 수 없습니다."),
+    MEMO_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "MEMO4031", "해당 메모를 수정할 권한이 없습니다."),
+    MEMO_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "MEMO4001", "메모 내용은 800자를 초과할 수 없습니다."),
+
     REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "FAMILYJOIN4040", "가입 요청을 찾을 수 없습니다."),
 
 

--- a/src/main/java/com/seasonthon/everflow/app/memo/controller/MemoController.java
+++ b/src/main/java/com/seasonthon/everflow/app/memo/controller/MemoController.java
@@ -5,11 +5,13 @@ import com.seasonthon.everflow.app.global.oauth.domain.CustomUserDetails;
 import com.seasonthon.everflow.app.memo.dto.MemoDto;
 import com.seasonthon.everflow.app.memo.dto.UpdateMemoRequestDto;
 import com.seasonthon.everflow.app.memo.service.MemoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,11 +19,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/memo")
+@Tag(name = "Memo API", description = "메모 관련 API")
 public class MemoController {
 
     private final MemoService memoService;
 
     /* 로그인한 사용자의 가족 메모 조회 (가족당 1장, 항상 존재) */
+    @Operation(summary = "우리 가족 메모 조회", description = "로그인한 사용자가 속한 가족의 공유 메모를 조회합니다. " + "가족당 1장만 존재하며, 조회 시 메모가 없으면 자동으로 생성됩니다.")
     @GetMapping
     public ApiResponse<MemoDto> getMemo(@AuthenticationPrincipal CustomUserDetails me) {
         return ApiResponse.onSuccess(
@@ -29,12 +33,13 @@ public class MemoController {
         );
     }
 
-    /* 메모 수정 (낙관적 락: version 필요) */
-    @PutMapping
+    /* 메모 수정 (본문만 수정, 버전은 서버 자동 관리) */
+    @Operation(summary = "우정리 가족 메모 수정", description = "로그인한 사용자가 속한 가족의 공유 메모 본문을 수정합니다. " + "버전은 서버에서 자동 관리되며, 본문만 수정 가능합니다. " + "최대 800자까지 입력할 수 있습니다.")
+    @PatchMapping
     public ApiResponse<MemoDto> updateMemo(@AuthenticationPrincipal CustomUserDetails me,
                                            @RequestBody @Valid UpdateMemoRequestDto req) {
         return ApiResponse.onSuccess(
-                memoService.update(me.getUserId(), req.version(), req.content())
+                memoService.update(me.getUserId(), req.content())
         );
     }
 }

--- a/src/main/java/com/seasonthon/everflow/app/memo/controller/MemoController.java
+++ b/src/main/java/com/seasonthon/everflow/app/memo/controller/MemoController.java
@@ -10,11 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,7 +21,7 @@ public class MemoController {
     private final MemoService memoService;
 
     /* 로그인한 사용자의 가족 메모 조회 (가족당 1장, 항상 존재) */
-    @Operation(summary = "우리 가족 메모 조회", description = "로그인한 사용자가 속한 가족의 공유 메모를 조회합니다. " + "가족당 1장만 존재하며, 조회 시 메모가 없으면 자동으로 생성됩니다.")
+    @Operation(summary = "우리 가족 메모 조회", description = "로그인한 사용자가 속한 가족의 메모를 조회합니다. " + "가족당 1장만 존재하며, 조회 시 메모가 없으면 자동으로 생성됩니다.")
     @GetMapping
     public ApiResponse<MemoDto> getMemo(@AuthenticationPrincipal CustomUserDetails me) {
         return ApiResponse.onSuccess(
@@ -34,7 +30,7 @@ public class MemoController {
     }
 
     /* 메모 수정 (본문만 수정, 버전은 서버 자동 관리) */
-    @Operation(summary = "우정리 가족 메모 수정", description = "로그인한 사용자가 속한 가족의 공유 메모 본문을 수정합니다. " + "버전은 서버에서 자동 관리되며, 본문만 수정 가능합니다. " + "최대 800자까지 입력할 수 있습니다.")
+    @Operation(summary = "우리 가족 메모 수정", description = "로그인한 사용자가 속한 가족의 메모 본문을 수정합니다. " + "버전은 서버에서 자동 관리되며, 최종 본문 길이는 최대 800자입니다.")
     @PatchMapping
     public ApiResponse<MemoDto> updateMemo(@AuthenticationPrincipal CustomUserDetails me,
                                            @RequestBody @Valid UpdateMemoRequestDto req) {

--- a/src/main/java/com/seasonthon/everflow/app/memo/controller/MemoController.java
+++ b/src/main/java/com/seasonthon/everflow/app/memo/controller/MemoController.java
@@ -1,0 +1,40 @@
+package com.seasonthon.everflow.app.memo.controller;
+
+import com.seasonthon.everflow.app.global.code.dto.ApiResponse;
+import com.seasonthon.everflow.app.global.oauth.domain.CustomUserDetails;
+import com.seasonthon.everflow.app.memo.dto.MemoDto;
+import com.seasonthon.everflow.app.memo.dto.UpdateMemoRequestDto;
+import com.seasonthon.everflow.app.memo.service.MemoService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/memo")
+public class MemoController {
+
+    private final MemoService memoService;
+
+    /* 로그인한 사용자의 가족 메모 조회 (가족당 1장, 항상 존재) */
+    @GetMapping
+    public ApiResponse<MemoDto> getMemo(@AuthenticationPrincipal CustomUserDetails me) {
+        return ApiResponse.onSuccess(
+                memoService.getOrCreate(me.getUserId())
+        );
+    }
+
+    /* 메모 수정 (낙관적 락: version 필요) */
+    @PutMapping
+    public ApiResponse<MemoDto> updateMemo(@AuthenticationPrincipal CustomUserDetails me,
+                                           @RequestBody @Valid UpdateMemoRequestDto req) {
+        return ApiResponse.onSuccess(
+                memoService.update(me.getUserId(), req.version(), req.content())
+        );
+    }
+}

--- a/src/main/java/com/seasonthon/everflow/app/memo/domain/Memo.java
+++ b/src/main/java/com/seasonthon/everflow/app/memo/domain/Memo.java
@@ -55,7 +55,8 @@ public class Memo {
     }
 
     // ---- behavior ----
-    public void applyContent(String newContent) {
+    public void applyContent(String newContent, Long editorUserId) {
         this.content = (newContent == null) ? "" : newContent;
+        this.updatedBy = editorUserId;
     }
 }

--- a/src/main/java/com/seasonthon/everflow/app/memo/domain/Memo.java
+++ b/src/main/java/com/seasonthon/everflow/app/memo/domain/Memo.java
@@ -1,0 +1,61 @@
+package com.seasonthon.everflow.app.memo.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "memos",
+        uniqueConstraints = @UniqueConstraint(name = "uq_memos_family", columnNames = "family_id"),
+        indexes = @Index(name = "idx_memos_updated_at", columnList = "updated_at")
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Memo {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "family_id", nullable = false, unique = true)
+    private Long familyId;
+
+    @Column(name = "updated_by", nullable = false)
+    private Long updatedBy;
+
+    /** 메모 본문 (최대 800자) */
+    @Column(nullable = false, length = 800)
+    private String content;
+
+    /** 낙관적 락 */
+    @Version
+    @Column(nullable = false)
+    private int version;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, columnDefinition = "datetime(6)")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false, columnDefinition = "datetime(6)")
+    private LocalDateTime updatedAt;
+
+    // ---- factory ----
+    private Memo(Long familyId, Long updatedBy) {
+        this.familyId = familyId;
+        this.updatedBy = updatedBy;
+        this.content = "";
+    }
+
+    public static Memo create(Long familyId, Long userId) {
+        return new Memo(familyId, userId);
+    }
+
+    // ---- behavior ----
+    public void applyContent(String newContent) {
+        this.content = (newContent == null) ? "" : newContent;
+    }
+}

--- a/src/main/java/com/seasonthon/everflow/app/memo/dto/MemoDto.java
+++ b/src/main/java/com/seasonthon/everflow/app/memo/dto/MemoDto.java
@@ -6,6 +6,5 @@ public record MemoDto(
         Long id,
         Long familyId,
         String content,
-        int version,
         LocalDateTime updatedAt
 ) {}

--- a/src/main/java/com/seasonthon/everflow/app/memo/dto/MemoDto.java
+++ b/src/main/java/com/seasonthon/everflow/app/memo/dto/MemoDto.java
@@ -1,0 +1,11 @@
+package com.seasonthon.everflow.app.memo.dto;
+
+import java.time.LocalDateTime;
+
+public record MemoDto(
+        Long id,
+        Long familyId,
+        String content,
+        int version,
+        LocalDateTime updatedAt
+) {}

--- a/src/main/java/com/seasonthon/everflow/app/memo/dto/MemoMapper.java
+++ b/src/main/java/com/seasonthon/everflow/app/memo/dto/MemoMapper.java
@@ -8,7 +8,6 @@ public class MemoMapper {
                 memo.getId(),
                 memo.getFamilyId(),
                 memo.getContent(),
-                memo.getVersion(),
                 memo.getUpdatedAt()
         );
     }

--- a/src/main/java/com/seasonthon/everflow/app/memo/dto/MemoMapper.java
+++ b/src/main/java/com/seasonthon/everflow/app/memo/dto/MemoMapper.java
@@ -1,0 +1,15 @@
+package com.seasonthon.everflow.app.memo.dto;
+
+import com.seasonthon.everflow.app.memo.domain.Memo;
+
+public class MemoMapper {
+    public static MemoDto toDto(Memo memo) {
+        return new MemoDto(
+                memo.getId(),
+                memo.getFamilyId(),
+                memo.getContent(),
+                memo.getVersion(),
+                memo.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/seasonthon/everflow/app/memo/dto/UpdateMemoRequestDto.java
+++ b/src/main/java/com/seasonthon/everflow/app/memo/dto/UpdateMemoRequestDto.java
@@ -4,6 +4,5 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record UpdateMemoRequestDto(
-        @NotNull Integer version,
         @Size(max = 800) String content
 ) {}

--- a/src/main/java/com/seasonthon/everflow/app/memo/dto/UpdateMemoRequestDto.java
+++ b/src/main/java/com/seasonthon/everflow/app/memo/dto/UpdateMemoRequestDto.java
@@ -1,0 +1,9 @@
+package com.seasonthon.everflow.app.memo.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UpdateMemoRequestDto(
+        @NotNull Integer version,
+        @Size(max = 800) String content
+) {}

--- a/src/main/java/com/seasonthon/everflow/app/memo/repository/MemoRepository.java
+++ b/src/main/java/com/seasonthon/everflow/app/memo/repository/MemoRepository.java
@@ -1,0 +1,11 @@
+package com.seasonthon.everflow.app.memo.repository;
+
+import com.seasonthon.everflow.app.memo.domain.Memo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemoRepository extends JpaRepository<Memo, Long> {
+    Optional<Memo> findByFamilyId(Long familyId);
+    boolean existsByFamilyId(Long familyId);
+}

--- a/src/main/java/com/seasonthon/everflow/app/memo/service/MemoService.java
+++ b/src/main/java/com/seasonthon/everflow/app/memo/service/MemoService.java
@@ -44,7 +44,8 @@ public class MemoService {
         }
 
         /* 내용 반영: @Version으로 버전은 자동 증가됨 */
-        memo.applyContent(content);
+        /* 최근 수정자(updated_by) 기록 */
+        memo.applyContent(content, userId);
         try {
             Memo saved = memoRepository.save(memo);
             return MemoMapper.toDto(saved);

--- a/src/main/java/com/seasonthon/everflow/app/memo/service/MemoService.java
+++ b/src/main/java/com/seasonthon/everflow/app/memo/service/MemoService.java
@@ -1,0 +1,61 @@
+package com.seasonthon.everflow.app.memo.service;
+import com.seasonthon.everflow.app.global.exception.GeneralException;
+import com.seasonthon.everflow.app.global.code.status.ErrorStatus;
+
+import com.seasonthon.everflow.app.global.code.dto.ApiResponse;
+import com.seasonthon.everflow.app.memo.domain.Memo;
+import com.seasonthon.everflow.app.memo.dto.MemoDto;
+import com.seasonthon.everflow.app.memo.repository.MemoRepository;
+import com.seasonthon.everflow.app.memo.dto.MemoMapper;
+import com.seasonthon.everflow.app.user.domain.User;
+import com.seasonthon.everflow.app.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class MemoService {
+    private final MemoRepository memoRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public MemoDto getOrCreate(Long userId) {
+        Long familyId = resolveFamilyId(userId);
+        return memoRepository.findByFamilyId(familyId)
+                .map(MemoMapper::toDto)
+                .orElseGet(() -> {
+                    Memo memo = Memo.create(familyId, userId);
+                    Memo saved = memoRepository.save(memo);
+                    return MemoMapper.toDto(saved);
+                });
+    }
+
+    @Transactional
+    public MemoDto update(Long userId, Integer expectedVersion, String content) {
+        Long familyId = resolveFamilyId(userId);
+        Memo memo = memoRepository.findByFamilyId(familyId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMO_NOT_FOUND));
+        if (memo.getVersion() != expectedVersion) {
+            throw new GeneralException(
+                ErrorStatus.VERSION_CONFLICT
+            );
+        }
+        if (content != null && content.length() > 800) {
+            throw new GeneralException(ErrorStatus.MEMO_CONTENT_TOO_LONG);
+        }
+        memo.applyContent(content);
+        Memo saved = memoRepository.save(memo);
+        return MemoMapper.toDto(saved);
+    }
+
+    private Long resolveFamilyId(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        if (user.getFamily() == null) {
+            throw new GeneralException(ErrorStatus.NOT_IN_FAMILY_YET);
+        }
+        return user.getFamily().getId();
+    }
+}


### PR DESCRIPTION
<img width="1470" height="190" alt="image" src="https://github.com/user-attachments/assets/6b426b77-e2a9-4f8b-953c-b9bb16c8f109" />


- 메모 관련 조회/수정 api 구현
- 가족 질문 조회 api 는 기존 api 재활용
- @version으로 JPA의 낙관적 락(Optimistic Locking) 사용 -> 동시에 조회 가능 but, 동시 수정 불가