### PR TITLE
Bug#53 커스텀 가족 책장 질문 로직 수정

### DIFF
--- a/src/main/java/com/seasonthon/everflow/app/bookshelf/repository/BookshelfAnswerRepository.java
+++ b/src/main/java/com/seasonthon/everflow/app/bookshelf/repository/BookshelfAnswerRepository.java
@@ -13,4 +13,6 @@ public interface BookshelfAnswerRepository extends JpaRepository<BookshelfAnswer
 
     // 특정 사용자 + 여러 질문 id에 대한 답변들
     List<BookshelfAnswer> findAllByUserIdAndQuestionIdIn(Long userId, List<Long> questionIds);
+
+    long deleteByQuestionId(Long questionId);
 }

--- a/src/main/java/com/seasonthon/everflow/app/bookshelf/service/BookshelfService.java
+++ b/src/main/java/com/seasonthon/everflow/app/bookshelf/service/BookshelfService.java
@@ -158,6 +158,9 @@ public class BookshelfService {
         }
 
         // 주의: FK 제약(answers) 때문에 삭제가 거부될 수 있음. 필요 시 Answer 먼저 삭제하도록 확장.
+        // 먼저 해당 질문의 모든 답변 삭제 (FK 제약 회피)
+        answerRepository.deleteByQuestionId(questionId);
+        // 질문 삭제
         questionRepository.delete(q);
     }
 


### PR DESCRIPTION
<img width="1433" height="738" alt="image" src="https://github.com/user-attachments/assets/6b0eb186-84a0-45fb-bd17-c07e9f63df1e" />

특정 id 질문만 삭제 불가 X
-> 답변이 존재하는 질문 삭제 불가한 상태

=>답변 존재하는 커스텀 질문 삭제시에, 해당 질문에 대한 답변 삭제한 뒤에 커스텀 질문 삭제로 로직 수정